### PR TITLE
Recipe tweaks as we converge on the X.org build methodology.

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,7 +1,3 @@
-:: Just delegate to the Unixy script; but some of the X.org tarballs have
-:: config.guess files too ancient to recognize 64-bit Windows!
-curl -sSL -o config.guess "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess"
-curl -sSL -o config.sub "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub"
-if errorlevel 1 exit 1
+:: Just delegate to the Unixy script.
 bash %RECIPE_DIR%\build.sh
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,6 +2,12 @@
 
 set -e
 IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Fresh OS-guessing scripts from xorg-util-macros for win64
+for f in config.guess config.sub ; do
+    cp -p $PREFIX/share/util-macros/$f .
+done
+
 export PKG_CONFIG_LIBDIR=$PREFIX/lib/pkgconfig:$PREFIX/share/pkgconfig
 configure_args=(
     --prefix=$PREFIX
@@ -10,6 +16,7 @@ configure_args=(
     --disable-silent-rules
 )
 ./configure "${configure_args[@]}"
-make -j${CPU_COUNT}
+make -j$CPU_COUNT
 make install
 make check
+rm -rf $PREFIX/share/doc/${PKG_NAME#xorg-}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,6 @@ build:
 
 requirements:
   build:
-    - curl  # [win]
     - m2w64-pkg-config  # [win]
     - pkg-config  # [not win]
     - posix  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - windows-fd_bits.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
 
 requirements:
@@ -26,6 +26,7 @@ requirements:
     - pkg-config  # [not win]
     - posix  # [win]
     - toolchain
+    - xorg-util-macros
 
 test:
   commands:


### PR DESCRIPTION
Nothing big: get the update config.{guess,sub} scripts from the
xorg-util-macros package, adding it as a build dep. Remove some documentation
XML files that are not going to be used.