### PR TITLE
Fix the Xwinsock.h header for 64-bit Windows.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,9 +14,10 @@ source:
   sha256: {{ sha256 }}
   patches:
     - windows-fd_bits.patch  # [win]
+    - windows-int64.patch  # [win]
 
 build:
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
 
 requirements:

--- a/recipe/windows-int64.patch
+++ b/recipe/windows-int64.patch
@@ -1,0 +1,18 @@
+--- Xwinsock.h.orig	2017-01-19 10:23:40.556270706 -0500
++++ Xwinsock.h	2017-01-19 10:24:01.590769551 -0500
+@@ -47,6 +47,7 @@
+ #define _NO_BOOL_TYPEDEF
+ #define BOOL WINBOOL
+ #define INT32 wINT32
++#define INT64 wINT64
+ #undef Status
+ #define Status wStatus
+ #define ATOM wATOM
+@@ -58,6 +59,7 @@
+ #undef BYTE
+ #undef BOOL
+ #undef INT32
++#undef INT64
+ #undef ATOM
+ #undef FreeResource
+ #undef CreateWindowA


### PR DESCRIPTION
Discovered while attempting to compile libXdmcp on Win64.